### PR TITLE
⚡ Optimize NSAttributedString instantiation in MarkdownParser

### DIFF
--- a/MarkTo/Models/MarkdownParser.swift
+++ b/MarkTo/Models/MarkdownParser.swift
@@ -33,6 +33,9 @@ class MarkdownParser {
     private let baseFont: NSFont
     private let codeFont: NSFont
     
+    // Cached common strings to avoid reallocation
+    private static let newlineString = NSAttributedString(string: "\n")
+
     init(baseFont: NSFont = NSFont.systemFont(ofSize: 14),
          codeFont: NSFont = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)) {
         
@@ -109,7 +112,7 @@ class MarkdownParser {
                         .backgroundColor: NSColor.controlBackgroundColor
                     ]
                 ))
-                result.append(NSAttributedString(string: "\n"))
+                result.append(MarkdownParser.newlineString)
                 i += 1
                 continue
             }
@@ -117,7 +120,7 @@ class MarkdownParser {
             // Parse the line based on its type
             let lineContent = parseLine(line, context: context, lines: lines, currentIndex: &i)
             result.append(lineContent)
-            result.append(NSAttributedString(string: "\n"))
+            result.append(MarkdownParser.newlineString)
             
             i += 1
         }
@@ -213,9 +216,9 @@ class MarkdownParser {
     private func handleEmptyLine(_ result: NSMutableAttributedString, context: ParsingContext) {
         if context.listContext.isInList {
             // Add reduced spacing within lists
-            result.append(NSAttributedString(string: "\n"))
+            result.append(MarkdownParser.newlineString)
         } else {
-            result.append(NSAttributedString(string: "\n"))
+            result.append(MarkdownParser.newlineString)
         }
     }
     
@@ -272,7 +275,7 @@ class MarkdownParser {
             let content = inlineProcessor.processInlineMarkdown(textWithoutTrailingSpaces, baseFont: context.baseFont, codeFont: context.codeFont)
             let result = NSMutableAttributedString()
             result.append(content)
-            result.append(NSAttributedString(string: "\n"))  // Hard line break
+            result.append(MarkdownParser.newlineString)  // Hard line break
             return result
         }
         


### PR DESCRIPTION
💡 **What:** Replaced repeated instantiations of `NSAttributedString(string: "\n")` with a cached static constant (`MarkdownParser.newlineString`).
🎯 **Why:** To prevent unnecessary memory allocations and initialization overhead inside parsing loops. Creating identical attributed string instances on every newline inside paragraphs, list items, and code blocks contributes to memory churn and CPU usage. Reusing a static immutable object is safer and more efficient.
📊 **Measured Improvement:** The development environment lacks native macOS/Swift build tools (`swift`, `xcodebuild`), so the exact execution time delta cannot be directly measured on this dev box. However, eliminating N allocations for an N-line markdown document reliably reduces allocation traffic proportional to the size of the document, which serves as a foundational performance improvement in text processing algorithms.

---
*PR created automatically by Jules for task [4345048825957356460](https://jules.google.com/task/4345048825957356460) started by @iamkeeler*