### PR TITLE
Fix NSTextTable API Usage and Implement Native RTF Tables

### DIFF
--- a/MarkTo/Models/TableProcessor.swift
+++ b/MarkTo/Models/TableProcessor.swift
@@ -135,27 +135,10 @@ class TableProcessor {
     // MARK: - RTF Table Generation
     
     private func generateRTFTable(from tableData: TableData, context: ParsingContext) -> NSAttributedString {
-        // Try HTML table approach first - many apps recognize HTML table structure better than RTF
-        let htmlTable = generateHTMLTable(from: tableData)
-        
-        // Convert HTML to NSAttributedString
-        if let htmlData = htmlTable.data(using: .utf8),
-           let attributedString = try? NSAttributedString(
-            data: htmlData,
-            options: [
-                .documentType: NSAttributedString.DocumentType.html,
-                .characterEncoding: String.Encoding.utf8.rawValue
-            ],
-            documentAttributes: nil
-           ) {
-            return attributedString
-        } else {
-            // HTML parsing failed, fall back to plain text table
-            return generatePlainTextTable(from: tableData, context: context)
-        }
+        // Use native RTF table generation as it provides better integration with Rich Text editors
+        return generateNativeRTFTable(from: tableData, context: context)
     }
     
-    // TODO: Fix NSTextTable API usage - currently has compilation errors
     private func generateNativeRTFTable(from tableData: TableData, context: ParsingContext) -> NSAttributedString {
         let result = NSMutableAttributedString()
         
@@ -195,7 +178,6 @@ class TableProcessor {
         return result
     }
 
-    // TODO: Fix NSTextTable API usage - part of native RTF table generation
     private func createTableRow(
         cells: [String],
         table: NSTextTable,
@@ -213,10 +195,13 @@ class TableProcessor {
             let cellBlock = NSTextTableBlock(table: table, startingRow: rowIndex, rowSpan: 1, startingColumn: columnIndex, columnSpan: 1)
             
             // Configure cell appearance
-            let borderColor = NSColor.separatorColor
-            cellBlock.setBorderColor(borderColor)
+            let borderColor = NSColor.separator
+            let edges: [NSRectEdge] = [.minX, .maxX, .minY, .maxY]
 
-            cellBlock.setWidth(0.5, type: .absoluteValueType, for: .border)
+            for edge in edges {
+                cellBlock.setBorderColor(borderColor, for: edge)
+                cellBlock.setWidth(0.5, type: .absoluteValue, for: .border, edge: edge)
+            }
             
             // Set cell background
             if isHeader {
@@ -226,10 +211,10 @@ class TableProcessor {
             }
             
             // Set cell padding
-            cellBlock.setWidth(4.0, type: .absoluteValueType, for: .padding, edge: .minX)
-            cellBlock.setWidth(4.0, type: .absoluteValueType, for: .padding, edge: .maxX)
-            cellBlock.setWidth(2.0, type: .absoluteValueType, for: .padding, edge: .minY)
-            cellBlock.setWidth(2.0, type: .absoluteValueType, for: .padding, edge: .maxY)
+            cellBlock.setWidth(4.0, type: .absoluteValue, for: .padding, edge: .minX)
+            cellBlock.setWidth(4.0, type: .absoluteValue, for: .padding, edge: .maxX)
+            cellBlock.setWidth(2.0, type: .absoluteValue, for: .padding, edge: .minY)
+            cellBlock.setWidth(2.0, type: .absoluteValue, for: .padding, edge: .maxY)
             
             // Create paragraph style with table block
             let paragraphStyle = NSMutableParagraphStyle()
@@ -238,21 +223,24 @@ class TableProcessor {
             // Set text alignment
             paragraphStyle.alignment = .natural
             
-            // Create attributed string for cell content
-            let font = isHeader ? NSFont.boldSystemFont(ofSize: 13) : NSFont.systemFont(ofSize: 13)
-            let cellAttributedString = NSAttributedString(
-                string: cellContent,
-                attributes: [
-                    .font: font,
-                    .paragraphStyle: paragraphStyle,
-                    .foregroundColor: NSColor.textColor
-                ]
-            )
+            // Create attributed string for cell content with markdown support
+            let baseFont = isHeader ? NSFont.boldSystemFont(ofSize: context.baseFont.pointSize) : context.baseFont
+            let cellAttributedString = NSMutableAttributedString(attributedString: inlineProcessor.processInlineMarkdown(
+                cellContent,
+                baseFont: baseFont,
+                codeFont: context.codeFont
+            ))
             
+            // Add paragraph break after each cell (required by NSTextTableBlock layout)
+            // It must have the paragraph style with textBlocks to be recognized as part of the table
+            cellAttributedString.append(NSAttributedString(string: "\n"))
+            
+            // Apply paragraph style and text color to the entire cell content, including the newline
+            let fullRange = NSRange(location: 0, length: cellAttributedString.length)
+            cellAttributedString.addAttribute(.paragraphStyle, value: paragraphStyle, range: fullRange)
+            cellAttributedString.addAttribute(.foregroundColor, value: NSColor.textColor, range: fullRange)
+
             result.append(cellAttributedString)
-            
-            // Add paragraph break after each cell
-            result.append(NSAttributedString(string: "\n"))
         }
         
         return result

--- a/MarkToTests/TableConversionTests.swift
+++ b/MarkToTests/TableConversionTests.swift
@@ -33,8 +33,8 @@ final class TableConversionTests: XCTestCase {
             XCTAssertTrue(string.contains("City"), "Table header should be present")
             XCTAssertTrue(string.contains("John"), "Table data should be present")
             XCTAssertTrue(string.contains("Jane"), "Table data should be present")
-            XCTAssertTrue(string.contains("│"), "Table should have column separators")
-            XCTAssertTrue(string.contains("─"), "Table should have row separators")
+
+            // Native RTF tables use NSTextTable attributes, not plain text separators
         case .failure(let error):
             XCTFail("Table conversion failed: \(error)")
         }
@@ -105,7 +105,6 @@ final class TableConversionTests: XCTestCase {
             XCTAssertTrue(string.contains("Title"), "Table content should be present")
             XCTAssertTrue(string.contains("Paragraph"), "Table content should be present")
             XCTAssertTrue(string.contains("Text"), "Table content should be present")
-            XCTAssertTrue(string.contains("│"), "Table should have column separators")
         case .failure(let error):
             XCTFail("Table conversion failed: \(error)")
         }
@@ -161,8 +160,6 @@ final class TableConversionTests: XCTestCase {
             XCTAssertTrue(string.contains("B"), "Table header should be present")
             XCTAssertTrue(string.contains("1"), "Table data should be present")
             XCTAssertTrue(string.contains("2"), "Table data should be present")
-            XCTAssertTrue(string.contains("│"), "Table should have column separators")
-            XCTAssertTrue(string.contains("─"), "Table should have row separators")
         case .failure(let error):
             XCTFail("Table conversion failed: \(error)")
         }
@@ -179,9 +176,16 @@ final class TableConversionTests: XCTestCase {
         
         switch result {
         case .success(let attributedString):
-            let string = attributedString.string
-            XCTAssertTrue(string.contains("│"), "Table should have column separators even if empty")
-            XCTAssertTrue(string.contains("─"), "Table should have row separators even if empty")
+            // In native RTF, an empty table might just be newlines with table block attributes
+            XCTAssertGreaterThan(attributedString.length, 0, "Table should generate content even if empty")
+
+            var foundTableBlock = false
+            attributedString.enumerateAttribute(.paragraphStyle, in: NSRange(location: 0, length: attributedString.length)) { value, _, _ in
+                if let style = value as? NSParagraphStyle, !style.textBlocks.isEmpty {
+                    foundTableBlock = true
+                }
+            }
+            XCTAssertTrue(foundTableBlock, "Empty table should still have table block attributes")
         case .failure(let error):
             XCTFail("Table conversion failed: \(error)")
         }
@@ -215,8 +219,6 @@ final class TableConversionTests: XCTestCase {
             XCTAssertTrue(string.contains("John"), "Table data should be present")
             XCTAssertTrue(string.contains("This is a paragraph after"), "Content after table should be present")
             XCTAssertTrue(string.contains("List item 1"), "List content should be present")
-            XCTAssertTrue(string.contains("│"), "Table should have column separators")
-            XCTAssertTrue(string.contains("─"), "Table should have row separators")
         case .failure(let error):
             XCTFail("Table conversion failed: \(error)")
         }
@@ -236,7 +238,15 @@ final class TableConversionTests: XCTestCase {
             let string = attributedString.string
             XCTAssertTrue(string.contains("Name"), "Table header data should be present as normal row")
             XCTAssertTrue(string.contains(":  :"), "Invalid separator should be present as data")
-            XCTAssertFalse(string.contains("─"), "Table should not have header row separators since it lacks a valid separator")
+
+            // Check that it's NOT a table (no table blocks)
+            var foundTableBlock = false
+            attributedString.enumerateAttribute(.paragraphStyle, in: NSRange(location: 0, length: attributedString.length)) { value, _, _ in
+                if let style = value as? NSParagraphStyle, !style.textBlocks.isEmpty {
+                    foundTableBlock = true
+                }
+            }
+            XCTAssertFalse(foundTableBlock, "Malformed table should not have table block attributes")
         case .failure(let error):
             XCTFail("Table conversion failed: \(error)")
         }
@@ -253,7 +263,15 @@ final class TableConversionTests: XCTestCase {
         case .success(let attributedString):
             let string = attributedString.string
             XCTAssertTrue(string.contains("--x---"), "Invalid separator with invalid characters should be treated as data")
-            XCTAssertFalse(string.contains("─"), "Table should not have header row separators since it lacks a valid separator")
+
+            // Check that it's NOT a table (no table blocks)
+            var foundTableBlock = false
+            attributedString.enumerateAttribute(.paragraphStyle, in: NSRange(location: 0, length: attributedString.length)) { value, _, _ in
+                if let style = value as? NSParagraphStyle, !style.textBlocks.isEmpty {
+                    foundTableBlock = true
+                }
+            }
+            XCTAssertFalse(foundTableBlock, "Malformed table with invalid chars should not have table block attributes")
         case .failure(let error):
             XCTFail("Table conversion failed: \(error)")
         }


### PR DESCRIPTION
This PR fixes compilation errors and incorrect API usage in `TableProcessor.swift` related to `NSTextTable`. It implements native RTF table generation, ensuring that markdown formatting is supported within cells and that the table structure is correctly recognized by the macOS text system by applying paragraph styles to the cell's trailing newline. Unit tests have been updated to align with the new structural output.

---
*PR created automatically by Jules for task [2026649954556671105](https://jules.google.com/task/2026649954556671105) started by @iamkeeler*