### PR TITLE
🧹 [code health improvement] Remove redundant duplicate variable declarations in MarkdownParser.swift

### DIFF
--- a/MarkTo/Models/MarkdownParser.swift
+++ b/MarkTo/Models/MarkdownParser.swift
@@ -163,11 +163,9 @@ class MarkdownParser {
         }
         
         let nsTrimmedLine = trimmedLine as NSString
-        let lineRange = NSRange(location: 0, length: nsTrimmedLine.length)
+        let range = NSRange(location: 0, length: nsTrimmedLine.length)
 
         // Check for unordered lists
-        let nsTrimmedLine = trimmedLine as NSString
-        let range = NSRange(location: 0, length: nsTrimmedLine.length)
 
         if let match = ParsingContext.unorderedListPattern.firstMatch(in: trimmedLine, options: [], range: range) {
             let prefix = nsTrimmedLine.substring(with: match.range)


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is the duplicate and redundant declarations of `nsTrimmedLine` and `range`/`lineRange` around lines 165-170 in `MarkTo/Models/MarkdownParser.swift`.

💡 **Why:** This improves maintainability by removing redundant variables, eliminating dead code (`lineRange`), and fixing a Swift compilation error where variables are redeclared in the same scope.

✅ **Verification:** Verified the diff locally using `git diff` to ensure that only the duplicate lines were removed and `range` was correctly preserved. The resulting Swift code correctly creates `range` without the redundant variables.

✨ **Result:** The code is cleaner, more readable, and fixes Swift compiler redeclaration errors.

---
*PR created automatically by Jules for task [10849610460854519802](https://jules.google.com/task/10849610460854519802) started by @iamkeeler*